### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0](https://github.com/Kimundi/easy-hex/compare/v0.1.2...v1.0.0) - 2023-12-05
+
+### Changed
+- Released 1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-hex"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "An easy to use Hex string formatting wrapper"
 repository = "https://github.com/Kimundi/easy-hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-hex"
-version = "0.1.2"
+version = "1.0.0"
 edition = "2021"
 description = "An easy to use Hex string formatting wrapper"
 repository = "https://github.com/Kimundi/easy-hex"

--- a/src/from_str.rs
+++ b/src/from_str.rs
@@ -4,7 +4,7 @@ use crate::{decode_into, FromHexError, Hex, UpperHex};
 
 impl<T> FromStr for Hex<T>
 where
-    T: for<'a> From<&'a [u8]>,
+    T: for<'a> TryFrom<&'a [u8]>,
 {
     type Err = FromHexError;
 
@@ -15,7 +15,7 @@ where
 
 impl<T> FromStr for UpperHex<T>
 where
-    T: for<'a> From<&'a [u8]>,
+    T: for<'a> TryFrom<&'a [u8]>,
 {
     type Err = FromHexError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 
-#[cfg(feature = "serde")]
 mod decode;
 #[cfg(feature = "serde")]
 mod deserialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,16 @@
 #![doc = include_str!("../README.md")]
 
 mod decode;
+mod encode;
+
+mod fmt;
+mod from_str;
+
 #[cfg(feature = "serde")]
 mod deserialize;
-mod encode;
-mod fmt;
 #[cfg(feature = "serde")]
 mod serialize;
 
-mod from_str;
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
## 🤖 New release
* `easy-hex`: 0.1.2 -> 1.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0](https://github.com/Kimundi/easy-hex/compare/v0.1.2...v1.0.0) - 2023-12-05

### Changed
- Released 1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).