### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/Kimundi/easy-hex/compare/v1.0.0...v1.0.1) - 2023-12-05
+
+### Fixed
+- conditonal guard on wrong module
+
+### Other
+- reorder module defintions to be more clear
+- release
+- Fix wrong trait bound
+- Add FromStr impl
+- Prepare for 1.0 release
+- Make Readme nicer if rendered outside of rustdoc
+- Tweak docs and API
+- Tweak docs and API
+- Work on Readme, tweak Implementation
+- Document more, improve API, add more tests
+- split crate into features
+- start preparing for release
+- test pod
+- split and test Hex and UpperHex code
+- test with generic array
+- more tests, enable unsized
+- add many tests
+- init commit
+
 ## [1.0.0](https://github.com/Kimundi/easy-hex/compare/v0.1.2...v1.0.0) - 2023-12-05
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-hex"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "An easy to use Hex string formatting wrapper"
 repository = "https://github.com/Kimundi/easy-hex"


### PR DESCRIPTION
## 🤖 New release
* `easy-hex`: 1.0.0 -> 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/Kimundi/easy-hex/compare/v1.0.0...v1.0.1) - 2023-12-05

### Fixed
- conditonal guard on wrong module

### Other
- reorder module defintions to be more clear
- release
- Fix wrong trait bound
- Add FromStr impl
- Prepare for 1.0 release
- Make Readme nicer if rendered outside of rustdoc
- Tweak docs and API
- Tweak docs and API
- Work on Readme, tweak Implementation
- Document more, improve API, add more tests
- split crate into features
- start preparing for release
- test pod
- split and test Hex and UpperHex code
- test with generic array
- more tests, enable unsized
- add many tests
- init commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).